### PR TITLE
Fix github action

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -12,7 +12,6 @@ jobs:
           build: npm run build
           start: npm start
           wait-on: http://localhost:5000
-          browser: chrome
           record: true
         env:
           # pass the Dashboard record key as an environment variable

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,5 @@
 name: Cypress
-on: [pull_request]
+on: [push, pull_request]
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
@@ -9,4 +9,11 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v1
         with:
+          build: npm run build
           start: npm start
+          wait-on: http://localhost:5000
+          browser: chrome
+          record: true
+        env:
+          # pass the Dashboard record key as an environment variable
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:5000"
+  "baseUrl": "http://localhost:5000",
+  "projectId": "hgum62"
 }


### PR DESCRIPTION
This PR makes a few changes to our Github actions setup:

1. The most important changes are that it runs our `build` task (I think this was the underlying problem.)
2. It also waits for our server to load before running tests
3. It runs tests on the pushed build and the PRed build (whether tests would pass after merging)
4. It sets up an integration so tests are recorded in Cypress's dashboard
5. ~~It now runs in Chrome — actually that part probably isn't needed. I'm going to remove that and see if tests still pass. Stay tuned~~